### PR TITLE
Update tm_catalog.snippet.php

### DIFF
--- a/core/components/tag_manager2/elements/snippets/tm_catalog.snippet.php
+++ b/core/components/tag_manager2/elements/snippets/tm_catalog.snippet.php
@@ -28,9 +28,14 @@ $limit = isset($_GET['limit']) && is_numeric($_GET['limit']) ? $_GET['limit'] : 
 $debug = isset($snippetProperties['debug']) ? $snippetProperties['debug'] : false;
 $sortby = isset($_GET['sortby']) && !is_array($_GET['sortby']) ? htmlspecialchars(trim($_GET['sortby'])) : $modx->getOption('sortby',$snippetProperties,'pagetitle');
 $sortdir = isset($_GET['sortdir']) && !is_array($_GET['sortdir']) ? htmlspecialchars(trim($_GET['sortdir'])) : $modx->getOption('sortdir',$snippetProperties,'asc');
+$orderby = isset($snippetProperties['orderby']) ? json_decode($snippetProperties['orderby'], true) : array(); //берем параметр orderby из настроек, где он хранится в виле {"stock":"DESC"} 
 if(strtolower($sortdir)=='rand' || strtolower($sortby)=='rand') { $sortby = 'RAND()'; }
 
 $sorting = $tm_catalog->getSorting($sortby, $sortdir);
+
+/*объединяем параметр $orderby с сортировкой*/
+$orderby[$sorting['sortby']] =$sorting['sortdir'];
+$sorting['orderby']=json_encode($orderby);
 
 $properties = array_merge($config, $snippetProperties, $sorting);
 

--- a/core/components/tag_manager2/elements/snippets/tm_catalog.snippet.php
+++ b/core/components/tag_manager2/elements/snippets/tm_catalog.snippet.php
@@ -28,14 +28,14 @@ $limit = isset($_GET['limit']) && is_numeric($_GET['limit']) ? $_GET['limit'] : 
 $debug = isset($snippetProperties['debug']) ? $snippetProperties['debug'] : false;
 $sortby = isset($_GET['sortby']) && !is_array($_GET['sortby']) ? htmlspecialchars(trim($_GET['sortby'])) : $modx->getOption('sortby',$snippetProperties,'pagetitle');
 $sortdir = isset($_GET['sortdir']) && !is_array($_GET['sortdir']) ? htmlspecialchars(trim($_GET['sortdir'])) : $modx->getOption('sortdir',$snippetProperties,'asc');
-$orderby = isset($snippetProperties['orderby']) ? json_decode($snippetProperties['orderby'], true) : array(); //берем параметр orderby из настроек, где он хранится в виле {"stock":"DESC"} 
+$orderby = isset($snippetProperties['orderby']) ? json_decode($snippetProperties['orderby'], true) : array(); //берем параметр orderby из настроек, где он хранится в виде {"stock":"DESC"} 
 if(strtolower($sortdir)=='rand' || strtolower($sortby)=='rand') { $sortby = 'RAND()'; }
 
 $sorting = $tm_catalog->getSorting($sortby, $sortdir);
 
-/*объединяем параметр $orderby с сортировкой*/
-$orderby[$sorting['sortby']] =$sorting['sortdir'];
-$sorting['orderby']=json_encode($orderby);
+/* объединяем параметр $orderby с сортировкой */
+$orderby[$sorting['sortby']] = $sorting['sortdir'];
+$sorting['orderby'] = json_encode($orderby);
 
 $properties = array_merge($config, $snippetProperties, $sorting);
 


### PR DESCRIPTION
Подробности тут http://forum.modx-shopkeeper.ru/topic/669/интересно-ли-вам-наличие-в-tagmanager-viewswitch-сортировки-по-двум-полям-сразу/3

Что это дает?
Он дает расширение текущего функциоала - возможность сортировать по умолчанию по одному из полей задавая его в параметрах orderby к getProducts+tagManager и поверх него сортировать уже по другим полям используя viewswith+tagManager
 
Почему объединяем sotby и orderby?
функции sotby и orderby по сути дублируют друг друга, но при этом orderby имеет превалирующее значение. 
Т.е. если оставить orderby={"stock":"DESC"} и при этом добавить sortby=price и sortdir = asc, 
то будет работать только orderby={"stock":"DESC"}, чтобы сработало и  sortby=price, нужно сделать так 
orderby={"stock":"DESC", "price":"asc"}, как сделано в коде.